### PR TITLE
Base menu dataobject permissions on access to menus CMS section, update PHPDoc

### DIFF
--- a/src/admin/MenuSetAdmin.php
+++ b/src/admin/MenuSetAdmin.php
@@ -17,6 +17,8 @@ use SilverStripe\Forms\GridField\GridFieldExportButton;
  */
 class MenuSetAdmin extends ModelAdmin
 {
+    const CMS_ACCESS_PERMISSION = 'CMS_ACCESS_' . self::class;
+
     /**
      * Managed data objects for CMS
      * @var array

--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -3,17 +3,23 @@
 namespace gorriecoe\Menu\Models;
 
 use gorriecoe\Link\Models\Link;
-use gorriecoe\Menu\Models\MenuSet;
-use gorriecoe\Menu\Models\MenuLink;
+use gorriecoe\Menu\Admin\MenuSetAdmin;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
-use SilverStripe\Core\Convert;
+use SilverStripe\ORM\FieldType\DBInt;
+use SilverStripe\Security\Permission;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 /**
  * MenuLink
  *
  * @package silverstripe-menu
+ *
+ * @property int ParentID
+ * @property int MenuSetID
+ * @method \SilverStripe\ORM\DataList|MenuLink[] Children()
+ * @method MenuSet|null MenuSet()
+ * @method MenuLink|null Parent()
  */
 class MenuLink extends Link
 {
@@ -40,7 +46,7 @@ class MenuLink extends Link
      * @var array
      */
     private static $db = [
-        'Sort' => 'Int'
+        'Sort' => DBInt::class,
     ];
 
     /**
@@ -80,7 +86,7 @@ class MenuLink extends Link
 
     /**
      * CMS Fields
-     * @return FieldList
+     * @return \SilverStripe\Forms\FieldList
      */
     public function getCMSFields()
     {
@@ -126,18 +132,18 @@ class MenuLink extends Link
 
     /**
      * Relationship accessor for Graphql
-     * @return MenuLink
+     * @return MenuLink|null
      */
     public function getParent()
     {
-        if ($this->ParentID) {
-            return $this->Parent();
-        }
+        return $this->ParentID
+            ? $this->Parent()
+            : null;
     }
 
     /**
      * Relationship accessor for Graphql
-     * @return ManyManyList MenuLink
+     * @return \SilverStripe\ORM\ManyManyList|MenuLink[]
      */
     public function getChildren()
     {
@@ -152,5 +158,37 @@ class MenuLink extends Link
     {
         $this->setClass($this->LinkingMode());
         return parent::getClass();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canView($member = null)
+    {
+        return Permission::check(MenuSetAdmin::CMS_ACCESS_PERMISSION, 'any', $member);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canDelete($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canCreate($member = null, $context = [])
+    {
+        return Permission::check(MenuSetAdmin::CMS_ACCESS_PERMISSION, 'any', $member);
     }
 }

--- a/src/models/MenuSet.php
+++ b/src/models/MenuSet.php
@@ -2,15 +2,15 @@
 
 namespace gorriecoe\Menu\Models;
 
-// use GridFieldOrderableRows;
-
-use gorriecoe\Menu\Models\MenuLink;
+use gorriecoe\Menu\Admin\MenuSetAdmin;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
+use SilverStripe\ORM\FieldType\DBBoolean;
+use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\Security\Permission;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataObject;
@@ -21,6 +21,11 @@ use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
  * MenuSet
  *
  * @package silverstripe-menu
+ * @property string $Title
+ * @property string $Slug
+ * @property boolean $Nested
+ *
+ * @method \SilverStripe\ORM\HasManyList|MenuLink[] Links()
  */
 class MenuSet extends DataObject
 {
@@ -51,9 +56,9 @@ class MenuSet extends DataObject
      * @var array
      */
     private static $db = [
-        'Title' => 'Varchar(255)',
-        'Slug' => 'Varchar(255)',
-        'Nested' => 'Boolean'
+        'Title' => DBVarchar::class,
+        'Slug' => DBVarchar::class,
+        'Nested' => DBBoolean::class,
     ];
 
     /**
@@ -101,7 +106,7 @@ class MenuSet extends DataObject
             GridField::create(
                 'Links',
                 _t(__CLASS__ . '.FIELDLINKS', 'Links'),
-                $this->Links,
+                $this->Links(),
                 GridFieldConfig_RecordEditor::create()
                     ->addComponent(new GridFieldOrderableRows('Sort'))
             )
@@ -140,7 +145,7 @@ class MenuSet extends DataObject
      */
     public function canEdit($member = null)
     {
-        return Permission::check('SITEMENUEDIT', 'any', $member);
+        return Permission::check(MenuSetAdmin::CMS_ACCESS_PERMISSION, 'any', $member);
     }
 
     /**
@@ -150,7 +155,7 @@ class MenuSet extends DataObject
      */
     public function canView($member = null)
     {
-        return Permission::check('SITEMENUEDIT', 'any', $member);
+        return Permission::check(MenuSetAdmin::CMS_ACCESS_PERMISSION, 'any', $member);
     }
 
     /**
@@ -201,7 +206,7 @@ class MenuSet extends DataObject
 
     /**
      * Relationship accessor for Graphql
-     * @return ManyManyList MenuLink
+     * @return \SilverStripe\ORM\ManyManyList MenuLink
      */
     public function getLinks()
     {


### PR DESCRIPTION
Currently, the `SITEMENUEDIT` is not defined by any class implementing `PermissionProvider`, so there is no way to allow non-admin users access to edit menu items. They can be granted access to open the menus CMS section (via the auto generated `CMS_ACCESS_[class]` permission), but they won't be able to see/edit `MenuSet` and `MenuItem` objects without the admin permission (or manually giving groups `SITEMENUEDIT` via the database.

This PR ties the permissions to `CMS_ACCESS_` for `MenuSetAdmin`, so anyone with access to that section can edit the menu.

If this is accepted, could you please tag a release as we would like to use this functionality in our project.