### PR TITLE
BUG Fix MenuSet() not inheriting from parent menus

### DIFF
--- a/src/admin/MenuSetAdmin.php
+++ b/src/admin/MenuSetAdmin.php
@@ -3,17 +3,20 @@
 namespace gorriecoe\Menu\Admin;
 
 use gorriecoe\Menu\Models\MenuSet;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Admin\ModelAdmin;
-use SilverStripe\Forms\GridField\GridFieldPrintButton;
-use SilverStripe\Forms\GridField\GridFieldImportButton;
-use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldImportButton;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
+use SilverStripe\Security\Member;
 
 /**
  * CMS Admin area to maintain menus
  *
- * @package silverstripe
+ * @package    silverstripe
  * @subpackage silverstripe-menu
  */
 class MenuSetAdmin extends ModelAdmin
@@ -44,7 +47,7 @@ class MenuSetAdmin extends ModelAdmin
     private static $menu_priority = 9;
 
     /**
-     * @param Int $id
+     * @param Int       $id
      * @param FieldList $fields
      * @return Form
      */

--- a/src/extensions/MenuSetSubsiteExtension.php
+++ b/src/extensions/MenuSetSubsiteExtension.php
@@ -47,7 +47,7 @@ class MenuSetSubsiteExtension extends DataExtension
     public function onBeforeWrite()
     {
         $owner = $this->owner;
-        if(!$owner->ID && !$owner->SubsiteID){
+        if (!$owner->ID && !$owner->SubsiteID) {
             $owner->SubsiteID = Subsite::currentSubsiteID();
         }
         parent::onBeforeWrite();

--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -3,17 +3,23 @@
 namespace gorriecoe\Menu\Models;
 
 use gorriecoe\Link\Models\Link;
-use gorriecoe\Menu\Models\MenuSet;
-use gorriecoe\Menu\Models\MenuLink;
-use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
+use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\Security\Member;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 /**
  * MenuLink
  *
+ * @property int $MenuSetID
+ * @property int $ParentID
+ * @property int $Sort
+ * @method MenuLink Parent()
+ * @method HasManyList|MenuLink[] Children()
  * @package silverstripe-menu
  */
 class MenuLink extends Link implements
@@ -51,7 +57,7 @@ class MenuLink extends Link implements
      */
     private static $has_one = [
         'MenuSet' => MenuSet::class,
-        'Parent' => MenuLink::class
+        'Parent'  => MenuLink::class
     ];
 
     /**
@@ -68,9 +74,9 @@ class MenuLink extends Link implements
      * @var array
      */
     private static $summary_fields = [
-        'Title' => 'Title',
-        'TypeLabel' => 'Type',
-        'LinkURL' => 'Link',
+        'Title'          => 'Title',
+        'TypeLabel'      => 'Type',
+        'LinkURL'        => 'Link',
         'Children.Count' => 'Children'
     ];
 
@@ -132,13 +138,15 @@ class MenuLink extends Link implements
 
     /**
      * Relationship accessor for Graphql
-     * @return MenuLink
+     *
+     * @return MenuLink|null
      */
     public function getParent()
     {
         if ($this->ParentID) {
             return $this->Parent();
         }
+        return null;
     }
 
     /**
@@ -184,14 +192,14 @@ class MenuLink extends Link implements
     /**
      * DataObject create permissions
      * @param Member $member
-     * @param array $context Additional context-specific data which might
-     * affect whether (or where) this object could be created.
+     * @param array  $context Additional context-specific data which might
+     *                        affect whether (or where) this object could be created.
      * @return boolean
      */
     public function canCreate($member = null, $context = [])
     {
         if (isset($context['Parent'])) {
-             return $context['Parent']->canEdit();
+            return $context['Parent']->canEdit();
         }
         return $this->MenuSet()->canEdit();
     }

--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -107,14 +107,18 @@ class MenuLink extends Link implements
     }
 
     /**
-     * Event handler called after writing to the database.
+     * Inherit menuset from parent, if not directly assigned
+     *
+     * @return MenuSet
      */
-    public function onAfterWrite()
+    public function MenuSet()
     {
-        parent::onAfterWrite();
-        if ($this->ParentID > 0) {
-            $this->MenuSetID = $this->Parent()->MenuSetID;
+        if ($this->ParentID) {
+            return $this->Parent()->MenuSet();
         }
+        /** @var MenuSet $menuSet */
+        $menuSet = $this->getComponent('MenuSet');
+        return $menuSet;
     }
 
     /**

--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -166,7 +166,7 @@ class MenuLink extends Link implements
      */
     public function canView($member = null)
     {
-        return $this->MenuSet()->canEdit($member);
+        return true;
     }
 
     /**

--- a/src/models/MenuSet.php
+++ b/src/models/MenuSet.php
@@ -2,26 +2,31 @@
 
 namespace gorriecoe\Menu\Models;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
-use SilverStripe\Security\Permission;
-use SilverStripe\ORM\DB;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Control\Controller;
-use SilverStripe\Security\PermissionProvider;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
-use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
-use gorriecoe\Menu\Models\MenuLink;
 
 /**
  * MenuSet
  *
+ * @property string $Title
+ * @property string $Slug
+ * @property bool   $AllowChildren
+ * @method HasManyList|MenuLink[] Links()
  * @package silverstripe-menu
  */
 class MenuSet extends DataObject implements
@@ -55,8 +60,8 @@ class MenuSet extends DataObject implements
      * @var array
      */
     private static $db = [
-        'Title' => 'Varchar(255)',
-        'Slug' => 'Varchar(255)',
+        'Title'         => 'Varchar(255)',
+        'Slug'          => 'Varchar(255)',
         'AllowChildren' => 'Boolean'
     ];
 
@@ -74,7 +79,7 @@ class MenuSet extends DataObject implements
      * @var array
      */
     private static $summary_fields = [
-        'Title' => 'Title',
+        'Title'       => 'Title',
         'Links.Count' => 'Links'
     ];
 
@@ -97,7 +102,7 @@ class MenuSet extends DataObject implements
                 'Root',
                 Tab::create('Main')
             )
-            ->setTitle(_t(__CLASS__ . '.TABMAIN', 'Main'))
+                ->setTitle(_t(__CLASS__ . '.TABMAIN', 'Main'))
         );
 
         $fields->addFieldToTab(
@@ -126,7 +131,7 @@ class MenuSet extends DataObject implements
         foreach (MenuSet::get() as $menuset) {
             $key = $menuset->PermissionKey();
             $permissions[$key] = [
-                'name' => _t(
+                'name'     => _t(
                     __CLASS__ . '.EDITMENUSET',
                     "Manage links with in '{name}'",
                     [
@@ -223,7 +228,8 @@ class MenuSet extends DataObject implements
      *
      * @return string
      */
-    public function CMSEditLink() {
+    public function CMSEditLink()
+    {
         return Controller::join_links(
             Controller::curr()->Link(),
             'EditForm',


### PR DESCRIPTION
The current code uses `onAfterWrite` to ensure the MenuSetID is assigned to child records. However, that is never written to the database (since it's on AFTER write, by which time it's too late to set the field).

Instead of setting it at all in after / before write, I just override the MenuSet() method and dynamically inherit the set from the parent on the fly. This is a lot more robust and safer than requiring the field to be set at all. :)

I also cleaned up the code in a separate commit. I ran PSR2 formatter over the code, added db field and relation type hints, and fixed IDE warnings.