### PR TITLE
Remove client from expose

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
     "gorriecoe/silverstripe-link": "^1.1"
   },
   "extra": {
-    "installer-name": "menu",
-    "expose": [
-      "client"
-    ]
+    "installer-name": "menu"
   }
 }


### PR DESCRIPTION
Heya @gorriecoe I hope you're doing well.

I noticed you'd removed the client folder but it was still exposed (crashes on platform during deployment). This should fix that. 