### PR TITLE
BUG Fix issue with non-admins not being able to create new links

### DIFF
--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -135,7 +135,7 @@ class MenuLink extends Link implements
      */
     public function isAllowedChildren()
     {
-        return $this->MenuSet()->AllowChildren;
+        return $this->isInDB() && $this->MenuSet()->AllowChildren;
     }
 
     /**
@@ -206,7 +206,7 @@ class MenuLink extends Link implements
     /**
      * DataObject create permissions
      * @param Member $member
-     * @param array  $context Additional context-specific data which might
+     * @param array $context Additional context-specific data which might
      *                        affect whether (or where) this object could be created.
      * @return boolean
      */

--- a/src/models/MenuSet.php
+++ b/src/models/MenuSet.php
@@ -25,7 +25,7 @@ use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
  *
  * @property string $Title
  * @property string $Slug
- * @property bool   $AllowChildren
+ * @property bool $AllowChildren
  * @method HasManyList|MenuLink[] Links()
  * @package silverstripe-menu
  */
@@ -180,7 +180,16 @@ class MenuSet extends DataObject implements
         if ($extended !== null) {
             return $extended;
         }
-        return Permission::check($this->PermissionKey(), 'any', $member);
+
+        // Restrict permissions based on saved key
+        if ($this->isInDB()) {
+            return Permission::check($this->PermissionKey(), 'any', $member);
+        }
+
+        // If canEdit() is called on an unsaved singleton, default to any users with CMS access
+        // This allows MenuLink objects to be created via gridfield,
+        // which will call the singleton MenuSet::canEdit()
+        return Permission::check('CMS_ACCESS', 'any', $member);
     }
 
     /**


### PR DESCRIPTION
When a MenuLink() object is created via gridfield, it does not have either a ParentID nor a MenuSetID field. This causes canEdit() on the object to return false (except for ADMIN) users. The form is thus read-only and the user cannot create the record.

To resolve this, we ensure that MenuSet::canEdit() only checks for the specific permission if it is saved to the database. If it's a singleton, fail back to cms permissions.

Note that MenuLink::canCreate() still safely checks if the object can be created for a specific menuset. canEdit() unfortunately is called during the form rendering, which doesn't know about that parent.

cc @gorriecoe for review.