### PR TITLE
Update MenuLink.php

### DIFF
--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -83,7 +83,7 @@ class MenuLink extends Link
      * Default sort ordering
      * @var array
      */
-    private static $default_sort = ['Sort' => 'ASC'];
+    private static $default_sort = 'Sort ASC';
 
     /**
      * CMS Fields


### PR DESCRIPTION
Currently if on php 8.1 and the latest version of SS - Line 370 in /app/vendor/symbiote/silverstripe-gridfieldextensions/src/GridFieldOrderableRows.php throws an error as the sort is expected to be a string.  Setting to a default convention which will work.  See - https://github.com/symbiote/silverstripe-gridfieldextensions/issues/344 for more details