### PR TITLE
defaut_sort should be a string

### DIFF
--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -81,9 +81,9 @@ class MenuLink extends Link
 
     /**
      * Default sort ordering
-     * @var array
+     * @var string
      */
-    private static $default_sort = ['Sort' => 'ASC'];
+    private static $default_sort = 'Sort ASC';
 
     /**
      * CMS Fields


### PR DESCRIPTION
otherwise GridFieldOrderableRows throws an array to string conversion notice