### PR TITLE
cleanup: remove unused scaffolding configuration

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,12 +6,3 @@ Only:
 gorriecoe\Menu\Models\MenuSet:
   extensions:
     - gorriecoe\Menu\Extensions\MenuSetSubsiteExtension
----
-Only:
-  moduleexists: 'silverstripe/graphql'
----
-SilverStripe\GraphQL\Controller:
-  schema:
-    scaffolding_providers:
-      - gorriecoe\Menu\Models\MenuSet
-      - gorriecoe\Menu\Models\MenuLink


### PR DESCRIPTION
the scaffolding code was removed in https://github.com/gorriecoe/silverstripe-menu/commit/3da067c894c49e33d2fe3c8c7ed2fa423714c4af