### PR TITLE
Change $default_sort from array to string

### DIFF
--- a/src/models/MenuLink.php
+++ b/src/models/MenuLink.php
@@ -83,7 +83,7 @@ class MenuLink extends Link
      * Default sort ordering
      * @var array
      */
-    private static $default_sort = ['Sort' => 'ASC'];
+    private static $default_sort = 'Sort ASC';
 
     /**
      * CMS Fields


### PR DESCRIPTION
Avoids "[Warning] Array to string conversion" from gridfieldextensions requirement. 

See: https://github.com/symbiote/silverstripe-gridfieldextensions/issues/344